### PR TITLE
Add missing channel link to #rls-admins

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -43,7 +43,7 @@ Respectful behavior includes but is not limited to:
 * Avoid demeaning, discriminatory, harassing, hateful, or physically threatening behavior, speech, and imagery.  
 * Due regard for the feelings, wishes, rights, and traditions of others.
 
-If you need clarification on whether a communication, action, or behavior is respectful, ask the source instead of assuming. No, really. If you don't find clarity, ask your peers in [\#rls-culture](https://rands-leadership.slack.com/archives/C9Y28QLVC), ask the Administrators publicly in \#rls-admins, or DM the Administrators privately. We'd rather hear from you than hear about something you said or did after the fact, and we are here to help.
+If you need clarification on whether a communication, action, or behavior is respectful, ask the source instead of assuming. No, really. If you don't find clarity, ask your peers in [\#rls-culture](https://rands-leadership.slack.com/archives/C9Y28QLVC), ask the Administrators publicly in [\#rls-admins](https://rands-leadership.slack.com/archives/CQC5BGPAB), or DM the Administrators privately. We'd rather hear from you than hear about something you said or did after the fact, and we are here to help.
 
 Don't be a bystander; be a leader. Role model respectful behavior, but also help to address disrespect when you see it within your community. 
 


### PR DESCRIPTION
I noticed only one instance of a channel mention wasn't linked in the Code of Conduct. If not having a link was unintentional, this change adds a link to that instance.